### PR TITLE
prevent windows version to write socket info

### DIFF
--- a/definition.py
+++ b/definition.py
@@ -33,6 +33,7 @@ else:
 from .base import bpy, BPY, root_dot, database, Operator, Entity, Bundle
 from .common import FORMAT
 from .menu import default_klasses, definition_tree
+import sys
 
 class Base(Operator):
     bl_label = "Definitions"
@@ -1152,10 +1153,12 @@ class JobControl(Entity):
                 ("element connection, " if self.element_connection else "") +
                 ("node connection, " if self.node_connection else ""))
             f.write(s[:-2] + ";\n")
-        if self.select_timeout is not None:
-            f.write("\tselect timeout: " + BPY.FORMAT(self.select_timeout) + ";\n")
-        else:
-            f.write("\tselect timeout: forever;\n")
+        self.platform = sys.platform
+        if self.platform != "win32": # disables writing socket info on windows which causes MBDyn crash
+            if self.select_timeout is not None:
+                f.write("\tselect timeout: " + BPY.FORMAT(self.select_timeout) + ";\n")
+            else:
+                f.write("\tselect timeout: forever;\n")
         f.write("\tdefault orientation: " + self.default_orientation + ";\n")
         f.write("\toutput meter: " + self.meter_drive.string() +
             ";\n\toutput precision: " + FORMAT(self.output_precision) + ";\n" +

--- a/help/index.html
+++ b/help/index.html
@@ -62,6 +62,7 @@ To install BlenderAndMBDyn v2 (BAM) from the Blender interface go to menu <i>Fil
 The procedure is fairly straightfoward but a few details should be taken into consideration:
  <ul style="list-style-type:disc">
   <li>It is recommmended to use Blender 2.72 or newer and a recent MBDyn version;</li>
+  <li>For plotting to work, you may need to install both Pandas for Python v2 and Pandas for Python v3. For example, Blender, which marshals the Pandas data, uses v3 and Ubuntu, which presents the Pandas data, uses v3.</li>
   <li>Before reinstalling BAM, it should first be uninstalled from Blender which should also be restarted;</li>
   <li>The software is still in development and any bug reports are welcomed on the <a href="https://github.com/gdbaldw/BlenderAndMBDyn";>Github page</a>.</li>
 </ul> 


### PR DESCRIPTION
Dear Doug, I've tried on Windows 10 and the same "socket" issue exists. I am able to fix it with this small patch.
Once you accept the pull request I will be able to publicize that the latest BAMv2 version works on Windows.
Thanks and Best Regards,
-Louis
